### PR TITLE
Refactor: eliminate CSS/JS duplication across all game pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,6 @@ Every game page MUST include all of these in the `<head>`:
 <!-- Tailwind CDN -->
 <script src="https://cdn.tailwindcss.com"></script>
 
-<!-- Google AdSense - REQUIRED on every page -->
-<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4552090282675465" crossorigin="anonymous"></script>
 ```
 
 ### 3. Hamburger Nav (must be on every page)
@@ -212,7 +210,6 @@ Pages to update:
 ├── CNAME                         # Domain (dailyjamm.com)
 ├── sitemap.xml                   # SEO sitemap (update when adding pages)
 ├── robots.txt                    # Allows all crawling
-├── ads.txt                       # AdSense verification
 ├── assets/
 │   ├── css/styles.css            # Shared game styles
 │   ├── js/
@@ -233,7 +230,6 @@ Pages to update:
 
 ## Tracking IDs (do not change)
 - **Google Analytics**: `G-XLRXG28EZV`
-- **Google AdSense**: `ca-pub-4552090282675465`
 
 ## Game Design Conventions
 - **Daily reset**: Games use Chicago timezone (`America/Chicago` via `Intl.DateTimeFormat`) for consistent daily rotation
@@ -337,5 +333,4 @@ Pages to update:
 - **Curly quotes**: Always use straight quotes in JS (`'` and `"`, never `'` `'` `"` `"`). Curly quotes in onclick handlers cause silent JS failures.
 - **Nav sync**: The hamburger nav is duplicated in every page's HTML. When adding a game, you must update ALL pages' nav or they'll be out of sync.
 - **iOS safe areas**: Always include `viewport-fit=cover` and `apple-mobile-web-app-status-bar-style` metas.
-- **AdSense + Analytics**: Both scripts must be on every page. Missing them means lost revenue and tracking gaps.
 - **GitHub Pages cache mismatch**: After pushing JS + data file changes together, Pages may serve a stale JS with the new data (or vice versa), causing JS errors caught as "Failed to load puzzle." If this happens, a hard refresh or waiting a few minutes resolves it. Ensure JS and data changes are compatible in both old and new states when possible.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Press `Ctrl+C` in the terminal to stop the server.
 - BlackJackdle: "Out of chips" game-over screen now includes a Share Results button
 
 ### v1.4.0 - 2026-03-28
-- Added **About** page (`/about/`) and **Privacy Policy** page (`/privacy/`) - required for Google AdSense approval
+- Added **About** page (`/about/`) and **Privacy Policy** page (`/privacy/`)
 - Footer on homepage now links to About and Privacy Policy
 - Info section added to hamburger menu on all pages
 - BlackJackdle card draw animations: hit, double down, and dealer draws now use flying card animation

--- a/about/index.html
+++ b/about/index.html
@@ -34,8 +34,6 @@
 
   <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
-  <!-- Google AdSense -->
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4552090282675465" crossorigin="anonymous"></script>
 
   <style>
     :root {
@@ -73,6 +71,7 @@
     footer a { color: #6b7280; }
     footer a:hover { color: #fff; }
   </style>
+  <script src="/assets/js/menu.js" defer></script>
 </head>
 <body>
 
@@ -149,22 +148,10 @@
   </div>
 
   <script>
-    function toggleMenu() {
-      const d = document.getElementById('drawer');
-      const b = document.getElementById('backdrop');
-      const open = d.classList.toggle('open');
-      b.classList.toggle('open', open);
-      document.querySelector('.hamburger').setAttribute('aria-expanded', open ? 'true' : 'false');
-    }
-    function closeMenu() {
-      document.getElementById('drawer').classList.remove('open');
-      document.getElementById('backdrop').classList.remove('open');
-      document.querySelector('.hamburger').setAttribute('aria-expanded', 'false');
-    }
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
-  <!-- Cookie consent (required for AdSense) -->
+  <!-- Cookie consent -->
   <div id="dj-cookie-bar" style="display:none">
     <span>We use cookies for analytics and advertising. <a href="/privacy/">Privacy Policy</a></span>
     <button onclick="document.getElementById('dj-cookie-bar').style.display='none';localStorage.setItem('dj_cookie_ok','1')">Got it</button>

--- a/ads.txt
+++ b/ads.txt
@@ -1,1 +1,0 @@
-google.com, pub-4552090282675465, DIRECT, f08c47fec0942fa0

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,6 +1,38 @@
 /* Accessibility */
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
 
+/* ── Game page theme variables ── */
+:root {
+  --panel: #0f172a;
+  --brand: #10b981;
+  --muted: #cbd5e1;
+  --line:  #1f2937;
+}
+
+/* ── Semantic color tokens ── */
+:root {
+  --color-success: #4ade80;
+  --color-warn:    #fbbf24;
+  --color-danger:  #ef4444;
+  --color-info:    #60a5fa;
+}
+
+/* ── Hamburger nav (shared across all game pages) ── */
+.hamburger{position:fixed;top:20px;left:20px;z-index:1000;cursor:pointer;background:transparent;border:none;padding:0;appearance:none;-webkit-appearance:none}
+.hamburger:focus{outline:2px solid rgba(255,255,255,.25);outline-offset:4px;border-radius:10px}
+.hamburger-box{width:30px;height:30px;display:flex;flex-direction:column;justify-content:space-around;background:transparent;border-radius:8px;padding:6px;transition:.3s}
+.hamburger-box:hover{background:rgba(0,0,0,.3)}
+.hamburger-line{width:100%;height:3px;background:#fff;border-radius:2px}
+.backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);opacity:0;visibility:hidden;transition:.3s;z-index:998}
+.backdrop.open{opacity:1;visibility:visible}
+.drawer{position:fixed;top:0;left:-300px;width:300px;height:100vh;background:var(--panel);border-right:2px solid var(--brand);transition:left .3s ease;z-index:999;padding:80px 20px 20px;overflow-y:auto;-webkit-overflow-scrolling:touch}
+.drawer.open{left:0}
+.menu-sec{margin-bottom:1.5rem}
+.menu-title{font-size:1rem;font-weight:700;color:var(--brand);margin-bottom:.75rem;padding-bottom:.5rem;border-bottom:1px solid var(--line)}
+.menu-link{display:block;color:var(--muted);text-decoration:none;padding:.6rem 0;border-radius:5px;transition:.2s}
+.menu-link:hover{color:#fff;background:rgba(16,185,129,.1);padding-left:.5rem}
+header .hamburger{position:relative;top:auto;left:auto;margin-right:.5rem;z-index:1002}
+
 /* ── Cookie consent bar ── */
 #dj-cookie-bar {
   position: fixed;
@@ -287,6 +319,22 @@ input[type=range].slider::-moz-range-thumb {
 .cl-demo-phrase { font-size: 8px; font-weight: 700; color: rgba(16,185,129,0.5); letter-spacing: 1.5px; text-transform: uppercase; animation: cl-fade-up 0.3s ease; }
 .cl-demo-dot    { font-size: 8px; color: #2d3748; }
 
+/* Chain Link modal — bottom-sheet on mobile, centered on taller screens */
+#cl-modal { align-items: flex-end; padding: 0; }
+#cl-modal > div {
+  border-radius: 1.25rem 1.25rem 0 0;
+  max-height: 92vh;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+  padding-bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+}
+@media (min-height: 600px) {
+  #cl-modal { align-items: center; padding: 1rem; }
+  #cl-modal > div { border-radius: 1rem; max-height: 85vh; padding-bottom: 1.25rem; }
+}
+
 /* ── Themedle How to Play demo ──────────────────── */
 .td-bar {
   width: 4px;
@@ -308,6 +356,13 @@ input[type=range].slider::-moz-range-thumb {
 @keyframes td-bounce {
   0%   { transform: scaleY(0.15); }
   100% { transform: scaleY(1); }
+}
+
+/* Themedle modal — bottom-sheet on mobile, centered on taller screens */
+#td-modal { align-items: flex-end; }
+#td-modal > div { -webkit-overflow-scrolling: touch; overscroll-behavior: contain; }
+@media (min-height: 600px) {
+  #td-modal { align-items: center; }
 }
 
 /* ── BlackJackdle ──────────────────────────────────── */
@@ -1122,6 +1177,17 @@ input[type=range].slider::-moz-range-thumb {
   color: #94a3b8;
 }
 
+/* Spelldle modal — bottom-sheet on mobile, centered on taller screens */
+#spd-modal { align-items: flex-end; padding: 0; }
+#spd-modal > div {
+  border-radius: 1.25rem 1.25rem 0 0;
+  max-height: 92vh;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+  padding-bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+}
 @media (min-height: 600px) {
   #spd-modal { align-items: center; padding: 1rem; }
   #spd-modal > div {

--- a/assets/js/blackjackdle.js
+++ b/assets/js/blackjackdle.js
@@ -3,6 +3,10 @@ const BJGame = (function () {
   'use strict';
 
   /* ── Constants ── */
+  const MS_PER_HOUR = 3600000;
+  const MS_PER_MIN  = 60000;
+  const MS_PER_SEC  = 1000;
+
   const HANDS_PER_DAY = 3;
   const STARTING_CHIPS = 1000;
   const DAILY_BONUS_MIN = 50;
@@ -33,27 +37,15 @@ const BJGame = (function () {
   const $ = (id) => document.getElementById(id);
   let els = {};
 
-  /* ── Chicago date helper (DST-safe) ── */
-  function chicagoDate() {
-    const s = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Chicago' });
-    return s; // 'YYYY-MM-DD'
-  }
-  function chicagoMidnight() {
-    const now = new Date();
-    const chi = new Date(now.toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-    const tomorrow = new Date(chi);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    tomorrow.setHours(0, 0, 0, 0);
-    const diff = tomorrow - chi;
-    return Date.now() + diff;
-  }
+  /* ── Chicago date helpers (via shared DJUtils) ── */
+  const chicagoDate     = () => DJUtils.getChicagoDate();
+  const chicagoMidnight = () => DJUtils.getChicagoMidnight();
 
   /* ── LocalStorage ── */
   function loadStats() {
-    try { return JSON.parse(localStorage.getItem('bj_stats')) || { streak: 0, best: 0, played: 0 }; }
-    catch { return { streak: 0, best: 0, played: 0 }; }
+    return DJUtils.loadJSON('bj_stats', { streak: 0, best: 0, played: 0 });
   }
-  function saveStats(s) { localStorage.setItem('bj_stats', JSON.stringify(s)); }
+  function saveStats(s) { DJUtils.saveJSON('bj_stats', s); }
 
   function loadToday() {
     try {
@@ -804,22 +796,10 @@ const BJGame = (function () {
       'dailyjamm.com/blackjackdle/';
   }
   function shareResults() {
-    if (navigator.clipboard) {
-      navigator.clipboard.writeText(buildShareText()).then(() => {
-        const btn = $('bj-share-btn');
-        btn.textContent = 'Copied!';
-        setTimeout(() => { btn.textContent = 'Share Results'; }, 2000);
-      });
-    }
+    DJUtils.clipboardShare(buildShareText(), $('bj-share-btn'), 'Share Results');
   }
   function shareBrokeResults() {
-    if (navigator.clipboard) {
-      navigator.clipboard.writeText(buildShareText()).then(() => {
-        const btn = $('bj-broke-share-btn');
-        btn.textContent = 'Copied!';
-        setTimeout(() => { btn.textContent = 'Share Results'; }, 2000);
-      });
-    }
+    DJUtils.clipboardShare(buildShareText(), $('bj-broke-share-btn'), 'Share Results');
   }
 
   /* ── Countdown ── */
@@ -829,13 +809,13 @@ const BJGame = (function () {
       const target = chicagoMidnight();
       const diff = target - Date.now();
       if (diff <= 0) { el.textContent = '00:00:00'; return; }
-      const h = Math.floor(diff / 3600000);
-      const m = Math.floor((diff % 3600000) / 60000);
-      const s = Math.floor((diff % 60000) / 1000);
+      const h = Math.floor(diff / MS_PER_HOUR);
+      const m = Math.floor((diff % MS_PER_HOUR) / MS_PER_MIN);
+      const s = Math.floor((diff % MS_PER_MIN) / MS_PER_SEC);
       el.textContent = String(h).padStart(2, '0') + ':' + String(m).padStart(2, '0') + ':' + String(s).padStart(2, '0');
     }
     tick();
-    setInterval(tick, 1000);
+    setInterval(tick, MS_PER_SEC);
   }
 
   /* ── Broke screen (ran out mid-session) ── */
@@ -873,13 +853,13 @@ const BJGame = (function () {
       const target = chicagoMidnight();
       const diff = target - Date.now();
       if (diff <= 0) { el.textContent = '00:00:00'; return; }
-      const h = Math.floor(diff / 3600000);
-      const m = Math.floor((diff % 3600000) / 60000);
-      const s = Math.floor((diff % 60000) / 1000);
+      const h = Math.floor(diff / MS_PER_HOUR);
+      const m = Math.floor((diff % MS_PER_HOUR) / MS_PER_MIN);
+      const s = Math.floor((diff % MS_PER_MIN) / MS_PER_SEC);
       el.textContent = String(h).padStart(2, '0') + ':' + String(m).padStart(2, '0') + ':' + String(s).padStart(2, '0');
     }
     tick();
-    setInterval(tick, 1000);
+    setInterval(tick, MS_PER_SEC);
   }
 
   /* ── Modal ── */

--- a/assets/js/chainlink.js
+++ b/assets/js/chainlink.js
@@ -1,13 +1,11 @@
 (function () {
   'use strict';
 
+  const SECONDS_PER_DAY  = 86400;
+  const SECONDS_PER_HOUR = 3600;
+
   // Puzzle data lives in /assets/data/chainlink-puzzles.json.
   // To add new puzzles, edit that file only - no changes needed here.
-
-  // ── Date helpers (DST-safe Chicago, matching Themedle) ───────────────────
-  function getTodayCST() {
-    return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Chicago' });
-  }
 
   // ── Puzzle selection ─────────────────────────────────────────────────────
   // Puzzle #1 plays on Jan 1 of each year. The day-of-year (1–365/366) maps
@@ -30,7 +28,7 @@
   }
 
   // ── State ────────────────────────────────────────────────────────────────
-  const todayCST = getTodayCST();
+  const todayCST = DJUtils.getChicagoDate();
   let puzzle; // set after fetch
   let currentStep = 0;
   let results     = [];   // { points: number }[]
@@ -46,8 +44,7 @@
   const SEEN_KEY  = 'cl_seen_howto';
 
   function loadStats() {
-    try { return JSON.parse(localStorage.getItem(STATS_KEY)) || { streak: 0, best: 0, played: 0, totalScore: 0, perfectGames: 0 }; }
-    catch { return { streak: 0, best: 0, played: 0, totalScore: 0, perfectGames: 0 }; }
+    return DJUtils.loadJSON(STATS_KEY, { streak: 0, best: 0, played: 0, totalScore: 0, perfectGames: 0 });
   }
 
   function saveStats(score) {
@@ -76,11 +73,11 @@
   }
 
   function saveTodayState() {
-    localStorage.setItem(TODAY_KEY, JSON.stringify({
+    DJUtils.saveJSON(TODAY_KEY, {
       todayDate: todayCST,
       puzzleId: puzzle.id,
       results, currentStep, gameOver, clueState,
-    }));
+    });
   }
 
   // ── Game helpers ─────────────────────────────────────────────────────────
@@ -304,11 +301,11 @@
       hour: '2-digit', minute: '2-digit', second: '2-digit',
     }).formatToParts(new Date());
     const map = Object.fromEntries(parts.map(p => [p.type, p.value]));
-    const secsToday = parseInt(map.hour) * 3600 + parseInt(map.minute) * 60 + parseInt(map.second);
-    let remaining = 86400 - secsToday;
+    const secsToday = parseInt(map.hour) * SECONDS_PER_HOUR + parseInt(map.minute) * 60 + parseInt(map.second);
+    let remaining = SECONDS_PER_DAY - secsToday;
     if (remaining < 0) remaining = 0;
-    const h = Math.floor(remaining / 3600);
-    const m = Math.floor((remaining % 3600) / 60);
+    const h = Math.floor(remaining / SECONDS_PER_HOUR);
+    const m = Math.floor((remaining % SECONDS_PER_HOUR) / 60);
     const s = remaining % 60;
     const el = document.getElementById('cl-countdown');
     if (el) el.textContent =
@@ -325,10 +322,7 @@
     const max     = perfect ? 20 : 15;
     const suffix  = perfect ? ' 🌟' : '';
     const text  = `Chain Link #${puzzle.id}\n${icons} ${score}/${max}${suffix}\nhttps://dailyjamm.com/chainlink/`;
-    navigator.clipboard.writeText(text).then(() => {
-      shareBtn.textContent = 'Copied!';
-      setTimeout(() => { shareBtn.textContent = 'Share Results'; }, 2000);
-    });
+    DJUtils.clipboardShare(text, shareBtn, 'Share Results');
   }
 
   // ── How to Play modal with animated demo ─────────────────────────────────

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,9 @@
 // main.js - Themedle game logic (with CSS-timed playback bar)
+(function () {
+'use strict';
+
+const SECONDS_PER_DAY  = 86400;
+const SECONDS_PER_HOUR = 3600;
 //
 // Expects these DOM IDs in index.html:
 // playBtn, volumeSlider, clipLength, progressBar, maxClipIndicator, guessInput,
@@ -198,9 +203,6 @@ const submitBtn = document.getElementById('submitGuess');
 const skipBtn = document.getElementById('skipGuess');
 
 // -------------------- Date Helpers (DST-safe Chicago) --------------------
-function getTodayCST() {
-  return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Chicago' });
-}
 function getChicagoYear() {
   return parseInt(new Intl.DateTimeFormat('en-CA', { timeZone: 'America/Chicago', year: 'numeric' }).format(new Date()), 10);
 }
@@ -238,7 +240,7 @@ function getDayIndexFromISO(dateISO) {
   return Math.floor(new Date(dateISO).getTime() / 86400000);
 }
 function getDailySongIndex() {
-  const todayISO = getTodayCST();
+  const todayISO = DJUtils.getChicagoDate();
   const order = getPermutation(themeSongs.length);
   const dayIndex = getDayIndexFromISO(todayISO);
   const idx = order[dayIndex % themeSongs.length];
@@ -292,7 +294,7 @@ function loadStats() {
   }
 }
 function saveStats() {
-  localStorage.setItem('themedleStats', JSON.stringify(gameStats));
+  DJUtils.saveJSON('themedleStats', gameStats);
 }
 function updateStatsDisplay() {
   const cur = document.getElementById('currentStreak');
@@ -306,7 +308,7 @@ function updateStatsDisplay() {
 // -------------------- Daily State --------------------
 function loadDailyGameState() {
   const saved = localStorage.getItem('themedleDailyState');
-  const today = getTodayCST();
+  const today = DJUtils.getChicagoDate();
   if (saved) {
     const savedState = JSON.parse(saved);
     if (savedState.date === today) {
@@ -326,7 +328,7 @@ function loadDailyGameState() {
   return false;
 }
 function saveDailyGameState() {
-  localStorage.setItem('themedleDailyState', JSON.stringify(dailyGameState));
+  DJUtils.saveJSON('themedleDailyState', dailyGameState);
 }
 
 // -------------------- UI Helpers --------------------
@@ -388,12 +390,11 @@ function updateCountdown() {
   const h = parseInt(map.hour, 10);
   const m = parseInt(map.minute, 10);
   const s = parseInt(map.second, 10);
-  const secsToday = h * 3600 + m * 60 + s;
-  const secsInDay = 24 * 3600;
-  let remaining = secsInDay - secsToday;
+  const secsToday = h * SECONDS_PER_HOUR + m * 60 + s;
+  let remaining = SECONDS_PER_DAY - secsToday;
   if (remaining < 0) remaining = 0;
-  const hours = Math.floor(remaining / 3600);
-  const minutes = Math.floor((remaining % 3600) / 60);
+  const hours = Math.floor(remaining / SECONDS_PER_HOUR);
+  const minutes = Math.floor((remaining % SECONDS_PER_HOUR) / 60);
   const seconds = remaining % 60;
   const el = document.getElementById('countdown');
   if (el) el.textContent = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
@@ -517,7 +518,7 @@ if (submitBtn) {
       saveDailyGameState();
       gameOver = true;
 
-      const today = getTodayCST();
+      const today = DJUtils.getChicagoDate();
       if (gameStats.lastPlayedDate !== today) {
         gameStats.currentStreak++;
         gameStats.gamesPlayed++;
@@ -548,7 +549,7 @@ if (submitBtn) {
         dailyGameState.won = false;
         saveDailyGameState();
         gameOver = true;
-        const today = getTodayCST();
+        const today = DJUtils.getChicagoDate();
         if (gameStats.lastPlayedDate !== today) {
           gameStats.currentStreak = 0;
           gameStats.gamesPlayed++;
@@ -593,7 +594,7 @@ if (skipBtn) {
         dailyGameState.won = false;
         saveDailyGameState();
         gameOver = true;
-        const today = getTodayCST();
+        const today = DJUtils.getChicagoDate();
         if (gameStats.lastPlayedDate !== today) {
           gameStats.currentStreak = 0;
           gameStats.gamesPlayed++;
@@ -782,3 +783,7 @@ function boot() {
 }
 
 document.addEventListener('DOMContentLoaded', boot);
+
+// Expose functions called from HTML onclick handlers
+window.closeStatsModal = closeStatsModal;
+})();

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -1,0 +1,28 @@
+// Shared hamburger menu logic for all DailyJamm pages
+(function () {
+  const drawer   = document.getElementById('drawer');
+  const backdrop = document.getElementById('backdrop');
+  const btn      = document.querySelector('.hamburger');
+
+  function openMenu() {
+    drawer.classList.add('open');
+    backdrop.classList.add('open');
+    document.documentElement.classList.add('overflow-hidden');
+    if (btn) btn.setAttribute('aria-expanded', 'true');
+    document.addEventListener('keydown', onKey);
+  }
+  function closeMenu() {
+    drawer.classList.remove('open');
+    backdrop.classList.remove('open');
+    document.documentElement.classList.remove('overflow-hidden');
+    if (btn) btn.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('keydown', onKey);
+  }
+  function toggleMenu() {
+    if (drawer.classList.contains('open')) { closeMenu(); } else { openMenu(); }
+  }
+  function onKey(e) { if (e.key === 'Escape') closeMenu(); }
+
+  window.toggleMenu = toggleMenu;
+  window.closeMenu  = closeMenu;
+})();

--- a/assets/js/roulettedle.js
+++ b/assets/js/roulettedle.js
@@ -3,6 +3,10 @@ const RLGame = (function () {
   'use strict';
 
   /* ── Constants ── */
+  const MS_PER_HOUR = 3600000;
+  const MS_PER_MIN  = 60000;
+  const MS_PER_SEC  = 1000;
+
   const SPINS_PER_DAY   = 3;
   const STARTING_CHIPS  = 1000;
   const DAILY_BONUS_MIN = 50;
@@ -35,25 +39,15 @@ const RLGame = (function () {
   /* ── DOM helper ── */
   const $ = (id) => document.getElementById(id);
 
-  /* ── Chicago date helpers (DST-safe) ── */
-  function chicagoDate() {
-    return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Chicago' });
-  }
-  function chicagoMidnight() {
-    const now = new Date();
-    const chi = new Date(now.toLocaleString('en-US', { timeZone: 'America/Chicago' }));
-    const tomorrow = new Date(chi);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    tomorrow.setHours(0, 0, 0, 0);
-    return Date.now() + (tomorrow - chi);
-  }
+  /* ── Chicago date helpers (via shared DJUtils) ── */
+  const chicagoDate     = () => DJUtils.getChicagoDate();
+  const chicagoMidnight = () => DJUtils.getChicagoMidnight();
 
   /* ── LocalStorage ── */
   function loadStats() {
-    try { return JSON.parse(localStorage.getItem('rl_stats')) || { streak: 0, best: 0, played: 0 }; }
-    catch { return { streak: 0, best: 0, played: 0 }; }
+    return DJUtils.loadJSON('rl_stats', { streak: 0, best: 0, played: 0 });
   }
-  function saveStats(s) { localStorage.setItem('rl_stats', JSON.stringify(s)); }
+  function saveStats(s) { DJUtils.saveJSON('rl_stats', s); }
 
   function loadToday() {
     try {
@@ -529,23 +523,11 @@ const RLGame = (function () {
   }
 
   function shareResults() {
-    if (navigator.clipboard) {
-      navigator.clipboard.writeText(buildShareText()).then(() => {
-        const btn = $('rl-share-btn');
-        btn.textContent = 'Copied!';
-        setTimeout(() => { btn.textContent = 'Share Results'; }, 2000);
-      });
-    }
+    DJUtils.clipboardShare(buildShareText(), $('rl-share-btn'), 'Share Results');
   }
 
   function shareBrokeResults() {
-    if (navigator.clipboard) {
-      navigator.clipboard.writeText(buildShareText()).then(() => {
-        const btn = $('rl-broke-share-btn');
-        btn.textContent = 'Copied!';
-        setTimeout(() => { btn.textContent = 'Share Results'; }, 2000);
-      });
-    }
+    DJUtils.clipboardShare(buildShareText(), $('rl-broke-share-btn'), 'Share Results');
   }
 
   /* ── Countdown ── */
@@ -554,13 +536,13 @@ const RLGame = (function () {
     function tick() {
       const diff = chicagoMidnight() - Date.now();
       const t = diff <= 0 ? '00:00:00' :
-        String(Math.floor(diff / 3600000)).padStart(2, '0') + ':' +
-        String(Math.floor((diff % 3600000) / 60000)).padStart(2, '0') + ':' +
-        String(Math.floor((diff % 60000) / 1000)).padStart(2, '0');
+        String(Math.floor(diff / MS_PER_HOUR)).padStart(2, '0') + ':' +
+        String(Math.floor((diff % MS_PER_HOUR) / MS_PER_MIN)).padStart(2, '0') + ':' +
+        String(Math.floor((diff % MS_PER_MIN) / MS_PER_SEC)).padStart(2, '0');
       targets.forEach(el => { if (el) el.textContent = t; });
     }
     tick();
-    setInterval(tick, 1000);
+    setInterval(tick, MS_PER_SEC);
   }
 
   /* ── Broke screen ── */

--- a/assets/js/spelldle.js
+++ b/assets/js/spelldle.js
@@ -17,6 +17,10 @@
   const CLASS_ABBREVS   = { bard:'Brd', cleric:'Clr', druid:'Drd', paladin:'Pal', ranger:'Rgr', sorcerer:'Sor', warlock:'Wlk', wizard:'Wiz' };
   const SCHOOL_ABBREVS  = { Abjuration:'Abj', Conjuration:'Conj', Divination:'Div', Enchantment:'Ench', Evocation:'Evoc', Illusion:'Illus', Necromancy:'Necro', Transmutation:'Trans' };
 
+  const SECONDS_PER_DAY  = 86400;
+  const SECONDS_PER_HOUR = 3600;
+  const SHARE_RESET_MS   = 2000;
+
   // Cached formatter for countdown — avoids creating a new object every second
   const COUNTDOWN_FMT = new Intl.DateTimeFormat('en-CA', {
     timeZone: 'America/Chicago',
@@ -25,16 +29,11 @@
     hour: '2-digit', minute: '2-digit', second: '2-digit',
   });
 
-  // ── Date helpers (DST-safe Chicago) ──────────────────────────────────────
-  function getTodayCST() {
-    return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Chicago' });
-  }
-
   // ── Puzzle selection (days since epoch, shuffled per cycle) ─────────────
   // Epoch = Jan 1 2026. Each cycle of N spells uses a seeded Fisher-Yates
   // shuffle so the order is random but deterministic (same spell for all
   // players on the same day) and every spell appears once before repeating.
-  var SPELL_EPOCH = new Date('2026-01-01T12:00:00Z');
+  const SPELL_EPOCH = new Date('2026-01-01T12:00:00Z');
 
   function getPuzzleIndex() {
     const parts = new Intl.DateTimeFormat('en-CA', {
@@ -51,10 +50,10 @@
 
   // Mulberry32 seeded RNG — deterministic, fast, good distribution
   function mulberry32(seed) {
-    var a = seed >>> 0;
+    let a = seed >>> 0;
     return function () {
       a = (a + 0x6D2B79F5) >>> 0;
-      var t = Math.imul(a ^ (a >>> 15), 1 | a);
+      let t = Math.imul(a ^ (a >>> 15), 1 | a);
       t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) | 0;
       return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
     };
@@ -62,21 +61,21 @@
 
   // Returns the spell array index for a given 1-indexed puzzle day
   function getShuffledSpellIndex(dayIndex, count) {
-    var cycle      = Math.floor((dayIndex - 1) / count);
-    var posInCycle = (dayIndex - 1) % count;
-    var seed       = (0xABCD1234 + cycle * 0x9E3779B9) >>> 0;
-    var rng        = mulberry32(seed);
-    var arr        = [];
-    for (var i = 0; i < count; i++) arr[i] = i;
-    for (var i = count - 1; i > 0; i--) {
-      var j   = Math.floor(rng() * (i + 1));
-      var tmp = arr[i]; arr[i] = arr[j]; arr[j] = tmp;
+    const cycle      = Math.floor((dayIndex - 1) / count);
+    const posInCycle = (dayIndex - 1) % count;
+    const seed       = (0xABCD1234 + cycle * 0x9E3779B9) >>> 0;
+    const rng        = mulberry32(seed);
+    const arr        = [];
+    for (let i = 0; i < count; i++) arr[i] = i;
+    for (let i = count - 1; i > 0; i--) {
+      const j   = Math.floor(rng() * (i + 1));
+      const tmp = arr[i]; arr[i] = arr[j]; arr[j] = tmp;
     }
     return arr[posInCycle];
   }
 
   // ── State ────────────────────────────────────────────────────────────────
-  const todayCST  = getTodayCST();
+  const todayCST  = DJUtils.getChicagoDate();
   let spells      = [];
   let answer      = null;
   let puzzleNum   = 1;
@@ -85,12 +84,11 @@
 
   // ── localStorage ─────────────────────────────────────────────────────────
   function loadStats() {
-    try { return JSON.parse(localStorage.getItem(STATS_KEY)) || { streak: 0, best: 0, played: 0, wins: 0 }; }
-    catch (e) { return { streak: 0, best: 0, played: 0, wins: 0 }; }
+    return DJUtils.loadJSON(STATS_KEY, { streak: 0, best: 0, played: 0, wins: 0 });
   }
 
   function saveStats(won) {
-    var s = loadStats();
+    const s = loadStats();
     s.played++;
     if (won) {
       s.wins = (s.wins || 0) + 1;
@@ -103,30 +101,30 @@
 
   function loadTodayState() {
     try {
-      var raw = localStorage.getItem(TODAY_KEY);
+      const raw = localStorage.getItem(TODAY_KEY);
       if (!raw) return null;
-      var d = JSON.parse(raw);
+      const d = JSON.parse(raw);
       if (d.todayDate !== todayCST) return null;
       return d;
     } catch (e) { return null; }
   }
 
   function saveTodayState() {
-    localStorage.setItem(TODAY_KEY, JSON.stringify({
+    DJUtils.saveJSON(TODAY_KEY, {
       todayDate: todayCST,
       puzzleNum: puzzleNum,
       guesses:   guesses,
       gameOver:  gameOver,
-    }));
+    });
   }
 
   // ── Comparison logic ─────────────────────────────────────────────────────
   function compareGuess(guess, ans) {
-    var results = [];
+    const results = [];
 
     // Level (0-9): green=exact, yellow=within ±2 with arrow, red=>2 off
     (function () {
-      var status, arrow = null;
+      let status, arrow = null;
       if (guess.level === ans.level) {
         status = 'green';
       } else if (Math.abs(guess.level - ans.level) <= 2) {
@@ -155,9 +153,9 @@
 
     // Range: green=exact, yellow=adjacent tier with arrow, red=>1 tier off
     (function () {
-      var gi = RANGE_TIERS.indexOf(guess.range);
-      var ai = RANGE_TIERS.indexOf(ans.range);
-      var status, arrow = null;
+      const gi = RANGE_TIERS.indexOf(guess.range);
+      const ai = RANGE_TIERS.indexOf(ans.range);
+      let status, arrow = null;
       if (gi === ai) {
         status = 'green';
       } else if (Math.abs(gi - ai) === 1) {
@@ -172,14 +170,14 @@
 
     // Components: green=exact, yellow=≥1 shared letter, red=no overlap
     (function () {
-      var gc = guess.components;
-      var ac = ans.components;
-      var status;
+      const gc = guess.components;
+      const ac = ans.components;
+      let status;
       if (gc === ac) {
         status = 'green';
       } else {
-        var shared = false;
-        for (var i = 0; i < gc.length; i++) {
+        let shared = false;
+        for (let i = 0; i < gc.length; i++) {
           if (ac.indexOf(gc[i]) !== -1) { shared = true; break; }
         }
         status = shared ? 'yellow' : 'red';
@@ -203,9 +201,9 @@
 
     // Duration: green=exact, yellow=adjacent tier with arrow, red=>1 tier off
     (function () {
-      var gi = DURATION_TIERS.indexOf(guess.duration);
-      var ai = DURATION_TIERS.indexOf(ans.duration);
-      var status, arrow = null;
+      const gi = DURATION_TIERS.indexOf(guess.duration);
+      const ai = DURATION_TIERS.indexOf(ans.duration);
+      let status, arrow = null;
       if (gi === ai) {
         status = 'green';
       } else if (Math.abs(gi - ai) === 1) {
@@ -220,21 +218,21 @@
 
     // Classes: green=exact same set, yellow=≥1 class in common, red=no overlap
     (function () {
-      var gc = (guess.classes || []).slice().sort();
-      var ac = (ans.classes   || []).slice().sort();
-      var status;
+      const gc = (guess.classes || []).slice().sort();
+      const ac = (ans.classes   || []).slice().sort();
+      let status;
       if (gc.join(',') === ac.join(',')) {
         status = 'green';
       } else {
-        var shared = gc.some(function (c) { return ac.indexOf(c) !== -1; });
+        const shared = gc.some(function (c) { return ac.indexOf(c) !== -1; });
         status = shared ? 'yellow' : 'red';
       }
-      var names = (guess.classes || []).map(function (c) { return CLASS_ABBREVS[c] || c; });
-      var display;
+      const names = (guess.classes || []).map(function (c) { return CLASS_ABBREVS[c] || c; });
+      let display;
       if (names.length <= 2) {
         display = names.join('/');
       } else if (names.length <= 4) {
-        var half = Math.ceil(names.length / 2);
+        const half = Math.ceil(names.length / 2);
         display = names.slice(0, half).join('/') + '\n' + names.slice(half).join('/');
       } else {
         display = names.slice(0, 2).join('/') + '\n' + names[2] + '+' + (names.length - 3);
@@ -250,20 +248,20 @@
   }
 
   // ── Autocomplete ─────────────────────────────────────────────────────────
-  var selectedDropdownIndex = -1;
-  var dropdownItems = [];
+  let selectedDropdownIndex = -1;
+  let dropdownItems = [];
 
   function guessedNames() {
     return guesses.map(function (g) { return g.spellName.toLowerCase(); });
   }
 
   function filterSpells(query) {
-    var q = query.toLowerCase().trim();
+    const q = query.toLowerCase().trim();
     if (!q) return [];
-    var already = new Set(guessedNames());
-    var startsWith = [], contains = [];
+    const already = new Set(guessedNames());
+    const startsWith = [], contains = [];
     spells.forEach(function (s) {
-      var n = s.name.toLowerCase();
+      const n = s.name.toLowerCase();
       if (already.has(n)) return;
       if (n.startsWith(q)) startsWith.push(s);
       else if (n.indexOf(q) !== -1) contains.push(s);
@@ -272,13 +270,13 @@
   }
 
   function renderDropdown(matches) {
-    var ul = document.getElementById('spd-dropdown');
+    const ul = document.getElementById('spd-dropdown');
     if (!matches.length) { ul.classList.add('hidden'); dropdownItems = []; selectedDropdownIndex = -1; return; }
     ul.innerHTML = '';
     dropdownItems = matches;
     selectedDropdownIndex = -1;
     matches.forEach(function (spell, i) {
-      var li = document.createElement('li');
+      const li = document.createElement('li');
       li.textContent = spell.name;
       li.setAttribute('role', 'option');
       li.setAttribute('data-index', i);
@@ -292,21 +290,21 @@
   }
 
   function hideDropdown() {
-    var ul = document.getElementById('spd-dropdown');
+    const ul = document.getElementById('spd-dropdown');
     ul.classList.add('hidden');
     dropdownItems = [];
     selectedDropdownIndex = -1;
   }
 
   function selectSpell(spell) {
-    var input = document.getElementById('spd-input');
+    const input = document.getElementById('spd-input');
     input.value = spell.name;
     hideDropdown();
     input.focus();
   }
 
   function highlightDropdownItem(index) {
-    var items = document.querySelectorAll('#spd-dropdown li');
+    const items = document.querySelectorAll('#spd-dropdown li');
     items.forEach(function (li, i) {
       li.classList.toggle('spd-dropdown-active', i === index);
     });
@@ -314,37 +312,37 @@
 
   // ── Board rendering ──────────────────────────────────────────────────────
   function renderBoard(animateLastRow) {
-    var board     = document.getElementById('spd-board');
-    var namesCol  = document.getElementById('spd-names');
+    const board     = document.getElementById('spd-board');
+    const namesCol  = document.getElementById('spd-names');
     board.innerHTML    = '';
     namesCol.innerHTML = '';
 
     guesses.forEach(function (guess, rowIndex) {
       // Name cell in frozen left column
-      var nameCell = document.createElement('div');
+      const nameCell = document.createElement('div');
       nameCell.className = 'spd-cell spd-name-cell';
       nameCell.textContent = guess.spellName;
       namesCol.appendChild(nameCell);
 
       // Attribute row in scrollable right panel
-      var row = document.createElement('div');
+      const row = document.createElement('div');
       row.className = 'spd-row';
 
       guess.results.forEach(function (r, colIndex) {
-        var cell = document.createElement('div');
+        const cell = document.createElement('div');
         cell.className = 'spd-cell spd-tile spd-' + r.status;
         if (animateLastRow && rowIndex === guesses.length - 1) {
           cell.style.animationDelay = (colIndex * 100) + 'ms';
           cell.classList.add('spd-tile-pop');
         }
 
-        var top = document.createElement('span');
+        const top = document.createElement('span');
         top.className = 'spd-tile-val';
         top.textContent = r.display;
         cell.appendChild(top);
 
         if (r.arrow) {
-          var arrow = document.createElement('span');
+          const arrow = document.createElement('span');
           arrow.className = 'spd-tile-arrow';
           arrow.textContent = r.arrow;
           cell.appendChild(arrow);
@@ -357,16 +355,16 @@
     });
 
     // Empty rows for remaining guesses
-    var remaining = MAX_GUESSES - guesses.length;
-    for (var i = 0; i < remaining; i++) {
-      var emptyName = document.createElement('div');
+    const remaining = MAX_GUESSES - guesses.length;
+    for (let i = 0; i < remaining; i++) {
+      const emptyName = document.createElement('div');
       emptyName.className = 'spd-cell spd-name-cell spd-empty-cell';
       namesCol.appendChild(emptyName);
 
-      var row = document.createElement('div');
+      const row = document.createElement('div');
       row.className = 'spd-row spd-row-empty';
-      for (var j = 0; j < 9; j++) {
-        var cell = document.createElement('div');
+      for (let j = 0; j < 9; j++) {
+        const cell = document.createElement('div');
         cell.className = 'spd-cell spd-tile spd-empty';
         row.appendChild(cell);
       }
@@ -377,20 +375,20 @@
 
     // Scroll attr panel to show latest row; sync name column
     if (animateLastRow) {
-      var attrScroll = document.getElementById('spd-attr-scroll');
+      const attrScroll = document.getElementById('spd-attr-scroll');
       attrScroll.scrollTop = attrScroll.scrollHeight;
       namesCol.scrollTop   = attrScroll.scrollTop;
     }
   }
 
   function updateGuessCounter() {
-    var el = document.getElementById('spd-guess-count');
+    const el = document.getElementById('spd-guess-count');
     if (el) el.textContent = guesses.length + ' / ' + MAX_GUESSES;
   }
 
   // ── Animations / toast ────────────────────────────────────────────────────
   function shakeInput() {
-    var row = document.getElementById('spd-input-row');
+    const row = document.getElementById('spd-input-row');
     row.classList.remove('spd-shake');
     void row.offsetWidth; // reflow
     row.classList.add('spd-shake');
@@ -398,7 +396,7 @@
   }
 
   function toastMessage(text) {
-    var toast = document.getElementById('spd-toast');
+    const toast = document.getElementById('spd-toast');
     toast.textContent = text;
     toast.classList.remove('hidden');
     toast.classList.add('spd-toast-show');
@@ -412,14 +410,14 @@
   function submitGuess() {
     if (gameOver) return;
 
-    var input = document.getElementById('spd-input');
-    var raw   = input.value.trim();
+    const input = document.getElementById('spd-input');
+    const raw   = input.value.trim();
     if (!raw) return;
 
     // Find matching spell (case-insensitive)
-    var guessSpell = null;
-    var rawLower = raw.toLowerCase();
-    for (var i = 0; i < spells.length; i++) {
+    let guessSpell = null;
+    const rawLower = raw.toLowerCase();
+    for (let i = 0; i < spells.length; i++) {
       if (spells[i].name.toLowerCase() === rawLower) { guessSpell = spells[i]; break; }
     }
 
@@ -436,7 +434,7 @@
       return;
     }
 
-    var results = compareGuess(guessSpell, answer);
+    const results = compareGuess(guessSpell, answer);
     guesses.push({ spellName: guessSpell.name, results: results });
     saveTodayState();
     input.value = '';
@@ -457,12 +455,12 @@
   }
 
   function handleWin() {
-    var stats = saveStats(true);
+    const stats = saveStats(true);
     showResults(false, true, stats);
   }
 
   function handleLoss() {
-    var stats = saveStats(false);
+    const stats = saveStats(false);
     showResults(false, false, stats);
   }
 
@@ -476,11 +474,11 @@
   }
 
   function showResults(isRestore, won, stats) {
-    var inputArea  = document.getElementById('spd-input-area');
-    var resultsEl  = document.getElementById('spd-results');
-    var heading    = document.getElementById('spd-result-heading');
-    var sub        = document.getElementById('spd-result-sub');
-    var ansReveal  = document.getElementById('spd-answer-reveal');
+    const inputArea  = document.getElementById('spd-input-area');
+    const resultsEl  = document.getElementById('spd-results');
+    const heading    = document.getElementById('spd-result-heading');
+    const sub        = document.getElementById('spd-result-sub');
+    const ansReveal  = document.getElementById('spd-answer-reveal');
 
     inputArea.classList.add('hidden');
     resultsEl.classList.remove('hidden');
@@ -510,13 +508,13 @@
 
   // ── Share ────────────────────────────────────────────────────────────────
   function handleShare() {
-    var won       = guesses.length > 0 && isWin(guesses[guesses.length - 1].results);
-    var winLine   = won ? guesses.length + '/' + MAX_GUESSES : 'X/' + MAX_GUESSES;
-    var text      = 'Spelldle #' + puzzleNum + ' \u2014 ' + winLine + '\nhttps://dailyjamm.com/spelldle/';
-    var btn       = document.getElementById('spd-share-btn');
+    const won       = guesses.length > 0 && isWin(guesses[guesses.length - 1].results);
+    const winLine   = won ? guesses.length + '/' + MAX_GUESSES : 'X/' + MAX_GUESSES;
+    const text      = 'Spelldle #' + puzzleNum + ' \u2014 ' + winLine + '\nhttps://dailyjamm.com/spelldle/';
+    const btn       = document.getElementById('spd-share-btn');
     navigator.clipboard.writeText(text).then(function () {
       btn.textContent = 'Copied!';
-      setTimeout(function () { btn.textContent = 'Share Results'; }, 2000);
+      setTimeout(function () { btn.textContent = 'Share Results'; }, SHARE_RESET_MS);
     }).catch(function () {
       toastMessage('Copy failed — try selecting the text manually.');
     });
@@ -524,14 +522,14 @@
 
   // ── Countdown ─────────────────────────────────────────────────────────────
   function updateCountdown() {
-    var parts = COUNTDOWN_FMT.formatToParts(new Date());
-    var map = Object.fromEntries(parts.map(function (p) { return [p.type, p.value]; }));
-    var secsToday = parseInt(map.hour) * 3600 + parseInt(map.minute) * 60 + parseInt(map.second);
-    var remaining = Math.max(0, 86400 - secsToday);
-    var h = Math.floor(remaining / 3600);
-    var m = Math.floor((remaining % 3600) / 60);
-    var s = remaining % 60;
-    var el = document.getElementById('spd-countdown');
+    const parts = COUNTDOWN_FMT.formatToParts(new Date());
+    const map = Object.fromEntries(parts.map(function (p) { return [p.type, p.value]; }));
+    const secsToday = parseInt(map.hour) * SECONDS_PER_HOUR + parseInt(map.minute) * 60 + parseInt(map.second);
+    const remaining = Math.max(0, SECONDS_PER_DAY - secsToday);
+    const h = Math.floor(remaining / SECONDS_PER_HOUR);
+    const m = Math.floor((remaining % SECONDS_PER_HOUR) / 60);
+    const s = remaining % 60;
+    const el = document.getElementById('spd-countdown');
     if (el) el.textContent =
       String(h).padStart(2, '0') + ':' +
       String(m).padStart(2, '0') + ':' +
@@ -550,14 +548,14 @@
 
   // ── Init ─────────────────────────────────────────────────────────────────
   function init() {
-    var dayIndex = getPuzzleIndex();
+    const dayIndex = getPuzzleIndex();
     puzzleNum    = dayIndex;
     answer       = spells[getShuffledSpellIndex(dayIndex, spells.length)];
 
     document.getElementById('spd-meta').textContent = 'Daily Spelldle #' + puzzleNum;
 
     // Restore saved state
-    var saved = loadTodayState();
+    const saved = loadTodayState();
     if (saved) {
       guesses  = saved.guesses  || [];
       gameOver = saved.gameOver || false;
@@ -580,18 +578,18 @@
     setInterval(updateCountdown, 1000);
 
     // Events
-    var input     = document.getElementById('spd-input');
-    var submitBtn = document.getElementById('spd-submit-btn');
-    var shareBtn  = document.getElementById('spd-share-btn');
-    var helpBtn   = document.getElementById('spd-help-btn');
-    var modal     = document.getElementById('spd-modal');
+    const input     = document.getElementById('spd-input');
+    const submitBtn = document.getElementById('spd-submit-btn');
+    const shareBtn  = document.getElementById('spd-share-btn');
+    const helpBtn   = document.getElementById('spd-help-btn');
+    const modal     = document.getElementById('spd-modal');
 
     input.addEventListener('input', function () {
       renderDropdown(filterSpells(input.value));
     });
 
     input.addEventListener('keydown', function (e) {
-      var items = document.querySelectorAll('#spd-dropdown li');
+      const items = document.querySelectorAll('#spd-dropdown li');
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         selectedDropdownIndex = Math.min(selectedDropdownIndex + 1, items.length - 1);
@@ -618,7 +616,7 @@
     });
 
     // Sync name column vertical scroll with attr panel
-    var attrScroll = document.getElementById('spd-attr-scroll');
+    const attrScroll = document.getElementById('spd-attr-scroll');
     attrScroll.addEventListener('scroll', function () {
       document.getElementById('spd-names').scrollTop = attrScroll.scrollTop;
     });
@@ -629,11 +627,11 @@
     document.getElementById('spd-modal-close').addEventListener('click', closeModal);
     modal.addEventListener('click', function (e) { if (e.target === modal) closeModal(); });
 
-    var statsBtn   = document.getElementById('spd-stats-btn');
-    var statsModal = document.getElementById('spd-stats-modal');
+    const statsBtn   = document.getElementById('spd-stats-btn');
+    const statsModal = document.getElementById('spd-stats-modal');
     if (statsBtn)   statsBtn.addEventListener('click', showStats);
     if (statsModal) statsModal.addEventListener('click', function (e) { if (e.target === statsModal) closeStats(); });
-    var statsClose = document.getElementById('spd-stats-close');
+    const statsClose = document.getElementById('spd-stats-close');
     if (statsClose) statsClose.addEventListener('click', closeStats);
 
     // ESC closes the modal (per site convention)
@@ -646,10 +644,10 @@
   }
 
   function showStats() {
-    var s      = loadStats();
-    var played = s.played || 0;
-    var wins   = s.wins   || 0;
-    var winPct = played > 0 ? Math.round(wins / played * 100) : 0;
+    const s      = loadStats();
+    const played = s.played || 0;
+    const wins   = s.wins   || 0;
+    const winPct = played > 0 ? Math.round(wins / played * 100) : 0;
 
     function row(label, value, color) {
       return '<div style="display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px solid #1f2937">' +
@@ -658,7 +656,7 @@
       '</div>';
     }
 
-    var el = document.getElementById('spd-stats-content');
+    const el = document.getElementById('spd-stats-content');
     if (el) {
       el.innerHTML =
         row('Games Played', played) +
@@ -667,12 +665,12 @@
         row('Current Streak', s.streak, '#facc15') +
         row('Best Streak', s.best, '#a78bfa');
     }
-    var statsModal = document.getElementById('spd-stats-modal');
+    const statsModal = document.getElementById('spd-stats-modal');
     if (statsModal) statsModal.classList.remove('hidden');
   }
 
   function closeStats() {
-    var statsModal = document.getElementById('spd-stats-modal');
+    const statsModal = document.getElementById('spd-stats-modal');
     if (statsModal) statsModal.classList.add('hidden');
   }
 

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -1,0 +1,45 @@
+// Shared utilities for all DailyJamm games
+window.DJUtils = (function () {
+  'use strict';
+
+  /** Returns today's date string in America/Chicago timezone (YYYY-MM-DD) */
+  function getChicagoDate() {
+    return new Date().toLocaleDateString('en-CA', { timeZone: 'America/Chicago' });
+  }
+
+  /** Returns ms timestamp of next Chicago midnight */
+  function getChicagoMidnight() {
+    const now = new Date();
+    const chi = new Date(now.toLocaleString('en-US', { timeZone: 'America/Chicago' }));
+    const tomorrow = new Date(chi);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(0, 0, 0, 0);
+    return Date.now() + (tomorrow - chi);
+  }
+
+  /** Load JSON from localStorage; return defaults on missing or corrupt data */
+  function loadJSON(key, defaults) {
+    try { return JSON.parse(localStorage.getItem(key)) || defaults; }
+    catch (e) { return defaults; }
+  }
+
+  /** Save data as JSON to localStorage */
+  function saveJSON(key, data) {
+    localStorage.setItem(key, JSON.stringify(data));
+  }
+
+  /**
+   * Copy text to clipboard and show "Copied!" feedback on a button.
+   * Restores resetLabel after 2 seconds.
+   */
+  function clipboardShare(text, btnEl, resetLabel) {
+    navigator.clipboard.writeText(text).then(function () {
+      btnEl.textContent = 'Copied!';
+      setTimeout(function () { btnEl.textContent = resetLabel; }, 2000);
+    }).catch(function () {
+      // Clipboard API unavailable — silent fallback
+    });
+  }
+
+  return { getChicagoDate, getChicagoMidnight, loadJSON, saveJSON, clipboardShare };
+})();

--- a/blackjackdle/index.html
+++ b/blackjackdle/index.html
@@ -36,32 +36,8 @@
 
   <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
-  <!-- AdSense not served on this page (simulated gambling content) -->
 
   <style>
-    :root {
-      --panel: #0f172a;
-      --brand: #10b981;
-      --muted: #cbd5e1;
-      --line:  #1f2937;
-    }
-
-    /* Hamburger + drawer */
-    .hamburger{position:fixed;top:20px;left:20px;z-index:1000;cursor:pointer;background:transparent;border:none;padding:0;appearance:none;-webkit-appearance:none}
-    .hamburger:focus{outline:2px solid rgba(255,255,255,.25);outline-offset:4px;border-radius:10px}
-    .hamburger-box{width:30px;height:30px;display:flex;flex-direction:column;justify-content:space-around;background:transparent;border-radius:8px;padding:6px;transition:.3s}
-    .hamburger-box:hover{background:rgba(0,0,0,.3)}
-    .hamburger-line{width:100%;height:3px;background:#fff;border-radius:2px}
-    .backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);opacity:0;visibility:hidden;transition:.3s;z-index:998}
-    .backdrop.open{opacity:1;visibility:visible}
-    .drawer{position:fixed;top:0;left:-300px;width:300px;height:100vh;background:var(--panel);border-right:2px solid var(--brand);transition:left .3s ease;z-index:999;padding:80px 20px 20px;overflow-y:auto;-webkit-overflow-scrolling:touch}
-    .drawer.open{left:0}
-    .menu-sec{margin-bottom:1.5rem}
-    .menu-title{font-size:1rem;font-weight:700;color:var(--brand);margin-bottom:.75rem;padding-bottom:.5rem;border-bottom:1px solid var(--line)}
-    .menu-link{display:block;color:var(--muted);text-decoration:none;padding:.6rem 0;border-radius:5px;transition:.2s}
-    .menu-link:hover{color:#fff;background:rgba(16,185,129,.1);padding-left:.5rem}
-    header .hamburger{position:relative;top:auto;left:auto;margin-right:.5rem;z-index:1002}
-
     body { overflow: hidden; }
   </style>
   <script type="application/ld+json">
@@ -77,6 +53,7 @@
     "author": { "@type": "Organization", "name": "DailyJamm", "url": "https://dailyjamm.com" }
   }
   </script>
+  <script src="/assets/js/menu.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white">
 
@@ -357,31 +334,9 @@
     </div>
   </div>
 
+  <script src="/assets/js/utils.js" defer></script>
   <script src="/assets/js/blackjackdle.js" defer></script>
 
-  <script>
-    (function(){
-      const drawer   = document.getElementById('drawer');
-      const backdrop = document.getElementById('backdrop');
-      function openMenu(){
-        drawer.classList.add('open');
-        backdrop.classList.add('open');
-        document.documentElement.classList.add('overflow-hidden');
-        document.addEventListener('keydown', onKey);
-      }
-      function closeMenu(){
-        drawer.classList.remove('open');
-        backdrop.classList.remove('open');
-        document.documentElement.classList.remove('overflow-hidden');
-        document.removeEventListener('keydown', onKey);
-      }
-      function toggleMenu(){
-        if(drawer.classList.contains('open')){ closeMenu(); } else { openMenu(); }
-      }
-      function onKey(e){ if(e.key === 'Escape') closeMenu(); }
-      window.toggleMenu = toggleMenu;
-      window.closeMenu  = closeMenu;
-    })();
-  </script>
+
 </body>
 </html>

--- a/chainlink/index.html
+++ b/chainlink/index.html
@@ -36,58 +36,11 @@
 
   <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
-  <!-- Google AdSense -->
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4552090282675465" crossorigin="anonymous"></script>
+
 
   <style>
-    :root {
-      --panel: #0f172a;
-      --brand: #10b981;
-      --muted: #cbd5e1;
-      --line:  #1f2937;
-    }
-
-    /* Hamburger + drawer - identical to Themedle */
-    .hamburger{position:fixed;top:20px;left:20px;z-index:1000;cursor:pointer;background:transparent;border:none;padding:0;appearance:none;-webkit-appearance:none}
-    .hamburger:focus{outline:2px solid rgba(255,255,255,.25);outline-offset:4px;border-radius:10px}
-    .hamburger-box{width:30px;height:30px;display:flex;flex-direction:column;justify-content:space-around;background:transparent;border-radius:8px;padding:6px;transition:.3s}
-    .hamburger-box:hover{background:rgba(0,0,0,.3)}
-    .hamburger-line{width:100%;height:3px;background:#fff;border-radius:2px}
-    .backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);opacity:0;visibility:hidden;transition:.3s;z-index:998}
-    .backdrop.open{opacity:1;visibility:visible}
-    .drawer{position:fixed;top:0;left:-300px;width:300px;height:100vh;background:var(--panel);border-right:2px solid var(--brand);transition:left .3s ease;z-index:999;padding:80px 20px 20px;overflow-y:auto;-webkit-overflow-scrolling:touch}
-    .drawer.open{left:0}
-    .menu-sec{margin-bottom:1.5rem}
-    .menu-title{font-size:1rem;font-weight:700;color:var(--brand);margin-bottom:.75rem;padding-bottom:.5rem;border-bottom:1px solid var(--line)}
-    .menu-link{display:block;color:var(--muted);text-decoration:none;padding:.6rem 0;border-radius:5px;transition:.2s}
-    .menu-link:hover{color:#fff;background:rgba(16,185,129,.1);padding-left:.5rem}
-    header .hamburger{position:relative;top:auto;left:auto;margin-right:.5rem;z-index:1002}
-
-    /* Prevent body scroll - game fills the viewport */
     body { overflow: hidden; }
-
-    /* Prevent iOS auto-zoom on input focus (triggered when font-size < 16px) */
-    #cl-guess-input { font-size: 16px; }
-
-    /* Modal - bottom-sheet on mobile, centered on taller screens */
-    #cl-modal { align-items: flex-end; padding: 0; }
-    #cl-modal > div {
-      border-radius: 1.25rem 1.25rem 0 0;
-      max-height: 92vh;
-      overflow-y: scroll;
-      -webkit-overflow-scrolling: touch;
-      overscroll-behavior: contain;
-      touch-action: pan-y;
-      padding-bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
-    }
-    @media (min-height: 600px) {
-      #cl-modal { align-items: center; padding: 1rem; }
-      #cl-modal > div {
-        border-radius: 1rem;
-        max-height: 85vh;
-        padding-bottom: 1.25rem;
-      }
-    }
+    #cl-guess-input { font-size: 16px; } /* Prevent iOS auto-zoom on input focus */
   </style>
   <script type="application/ld+json">
   {
@@ -102,6 +55,7 @@
     "author": { "@type": "Organization", "name": "DailyJamm", "url": "https://dailyjamm.com" }
   }
   </script>
+  <script src="/assets/js/menu.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white">
 
@@ -310,34 +264,10 @@
     </div>
   </div>
 
+  <script src="/assets/js/utils.js" defer></script>
   <script src="/assets/js/chainlink.js" defer></script>
 
-  <script>
-    (function(){
-      const drawer   = document.getElementById('drawer');
-      const backdrop = document.getElementById('backdrop');
-      function openMenu(){
-        drawer.classList.add('open');
-        backdrop.classList.add('open');
-        document.documentElement.classList.add('overflow-hidden');
-        document.addEventListener('keydown', onKey);
-      }
-      function closeMenu(){
-        drawer.classList.remove('open');
-        backdrop.classList.remove('open');
-        document.documentElement.classList.remove('overflow-hidden');
-        document.removeEventListener('keydown', onKey);
-      }
-      function toggleMenu(){
-        if(drawer.classList.contains('open')){ closeMenu(); } else { openMenu(); }
-      }
-      function onKey(e){ if(e.key === 'Escape') closeMenu(); }
-      window.toggleMenu = toggleMenu;
-      window.closeMenu  = closeMenu;
-    })();
-  </script>
-
-  <!-- Cookie consent (required for AdSense) -->
+  <!-- Cookie consent -->
   <div id="dj-cookie-bar" style="display:none">
     <span>We use cookies for analytics and advertising. <a href="/privacy/">Privacy Policy</a></span>
     <button onclick="document.getElementById('dj-cookie-bar').style.display='none';localStorage.setItem('dj_cookie_ok','1')">Got it</button>

--- a/index.html
+++ b/index.html
@@ -5,8 +5,6 @@
   <!-- NOTE: added viewport-fit=cover to ensure background fills notch/safe areas on iOS -->
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>DailyJamm - Daily Games Hub</title>
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4552090282675465"
-     crossorigin="anonymous"></script>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-XLRXG28EZV"></script>
   <script>
@@ -109,6 +107,7 @@
     "author": { "@type": "Organization", "name": "DailyJamm", "url": "https://dailyjamm.com" }
   }
   </script>
+  <script src="/assets/js/menu.js" defer></script>
 </head>
 <body>
   <!-- Hamburger button (persists in place; open and close) -->
@@ -363,26 +362,13 @@
   </main>
 
   <script>
-    function toggleMenu(){
-      const d=document.getElementById('drawer');
-      const b=document.getElementById('backdrop');
-      const btn=document.querySelector('.hamburger');
-      const open=d.classList.toggle('open');
-      b.classList.toggle('open',open);
-      btn.setAttribute('aria-expanded',open?'true':'false');
-    }
-    function closeMenu(){
-      document.getElementById('drawer').classList.remove('open');
-      document.getElementById('backdrop').classList.remove('open');
-      document.querySelector('.hamburger').setAttribute('aria-expanded','false');
-    }
     function openExternal(url){window.open(url,'_blank','noopener,noreferrer')}
     function goto(path){window.location.href=path}
     document.addEventListener('keydown',e=>{if(e.key==='Enter'&&document.activeElement&&document.activeElement.getAttribute('role')==='button'){document.activeElement.click()}})
     document.getElementById('year').textContent=new Date().getFullYear();
   </script>
 
-  <!-- Cookie consent (required for AdSense) -->
+  <!-- Cookie consent -->
   <div id="dj-cookie-bar" style="display:none;position:fixed;bottom:0;left:0;right:0;background:rgba(15,23,42,0.97);border-top:1px solid #1e293b;padding:10px 16px;align-items:center;justify-content:center;gap:12px;font-size:0.75rem;color:#94a3b8;z-index:9000;flex-wrap:wrap;text-align:center">
     <span>We use cookies for analytics and advertising. <a href="/privacy/" style="color:#2ecc71;text-decoration:underline">Privacy Policy</a></span>
     <button onclick="document.getElementById('dj-cookie-bar').style.display='none';localStorage.setItem('dj_cookie_ok','1')" style="background:#2ecc71;color:#111;border:none;padding:4px 14px;border-radius:4px;font-size:0.75rem;font-weight:700;cursor:pointer;flex-shrink:0">Got it</button>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -34,8 +34,6 @@
 
   <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
-  <!-- Google AdSense -->
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4552090282675465" crossorigin="anonymous"></script>
 
   <style>
     :root {
@@ -75,6 +73,7 @@
     footer a { color: #6b7280; }
     footer a:hover { color: #fff; }
   </style>
+  <script src="/assets/js/menu.js" defer></script>
 </head>
 <body>
 
@@ -142,11 +141,6 @@
     <p>We use <strong style="color:#fff">Google Analytics</strong> to understand aggregate traffic patterns (page views, general geography, device types). Google Analytics may set cookies in your browser. This data is anonymized and we do not use it to identify individuals.</p>
     <p>You can opt out of Google Analytics by installing the <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer">Google Analytics Opt-out Browser Add-on</a>.</p>
 
-    <h2>Advertising</h2>
-    <p>DailyJamm uses <strong style="color:#fff">Google AdSense</strong> to display advertisements. Google AdSense may use cookies and web beacons to serve ads based on your prior visits to this or other websites. Google's use of advertising cookies enables it and its partners to serve ads based on your visit to our site and/or other sites on the internet.</p>
-    <p>You may opt out of personalized advertising by visiting <a href="https://www.google.com/settings/ads" target="_blank" rel="noopener noreferrer">Google Ads Settings</a>. Alternatively, you can opt out via the <a href="https://www.networkadvertising.org/choices/" target="_blank" rel="noopener noreferrer">Network Advertising Initiative opt-out page</a>.</p>
-    <p>For more information on how Google uses data from sites that use its services, visit: <a href="https://policies.google.com/technologies/partner-sites" target="_blank" rel="noopener noreferrer">How Google uses data when you use our partners' sites or apps</a>.</p>
-
     <h2>Third-Party Links</h2>
     <p>DailyJamm includes links to third-party game sites (Wordle, Connections, Heardle, etc.). We are not responsible for the privacy practices of those sites. We encourage you to review their privacy policies before interacting with them.</p>
 
@@ -165,22 +159,10 @@
   </div>
 
   <script>
-    function toggleMenu() {
-      const d = document.getElementById('drawer');
-      const b = document.getElementById('backdrop');
-      const open = d.classList.toggle('open');
-      b.classList.toggle('open', open);
-      document.querySelector('.hamburger').setAttribute('aria-expanded', open ? 'true' : 'false');
-    }
-    function closeMenu() {
-      document.getElementById('drawer').classList.remove('open');
-      document.getElementById('backdrop').classList.remove('open');
-      document.querySelector('.hamburger').setAttribute('aria-expanded', 'false');
-    }
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
-  <!-- Cookie consent (required for AdSense) -->
+  <!-- Cookie consent -->
   <div id="dj-cookie-bar" style="display:none">
     <span>We use cookies for analytics and advertising. <a href="/privacy/">Privacy Policy</a></span>
     <button onclick="document.getElementById('dj-cookie-bar').style.display='none';localStorage.setItem('dj_cookie_ok','1')">Got it</button>

--- a/roulettedle/index.html
+++ b/roulettedle/index.html
@@ -36,34 +36,7 @@
 
   <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
-  <!-- AdSense not served on this page (simulated gambling content) -->
 
-  <style>
-    :root {
-      --panel: #0f172a;
-      --brand: #10b981;
-      --muted: #cbd5e1;
-      --line:  #1f2937;
-    }
-
-    /* Hamburger + drawer */
-    .hamburger{position:fixed;top:20px;left:20px;z-index:1000;cursor:pointer;background:transparent;border:none;padding:0;appearance:none;-webkit-appearance:none}
-    .hamburger:focus{outline:2px solid rgba(255,255,255,.25);outline-offset:4px;border-radius:10px}
-    .hamburger-box{width:30px;height:30px;display:flex;flex-direction:column;justify-content:space-around;background:transparent;border-radius:8px;padding:6px;transition:.3s}
-    .hamburger-box:hover{background:rgba(0,0,0,.3)}
-    .hamburger-line{width:100%;height:3px;background:#fff;border-radius:2px}
-    .backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);opacity:0;visibility:hidden;transition:.3s;z-index:998}
-    .backdrop.open{opacity:1;visibility:visible}
-    .drawer{position:fixed;top:0;left:-300px;width:300px;height:100vh;background:var(--panel);border-right:2px solid var(--brand);transition:left .3s ease;z-index:999;padding:80px 20px 20px;overflow-y:auto;-webkit-overflow-scrolling:touch}
-    .drawer.open{left:0}
-    .menu-sec{margin-bottom:1.5rem}
-    .menu-title{font-size:1rem;font-weight:700;color:var(--brand);margin-bottom:.75rem;padding-bottom:.5rem;border-bottom:1px solid var(--line)}
-    .menu-link{display:block;color:var(--muted);text-decoration:none;padding:.6rem 0;border-radius:5px;transition:.2s}
-    .menu-link:hover{color:#fff;background:rgba(16,185,129,.1);padding-left:.5rem}
-    header .hamburger{position:relative;top:auto;left:auto;margin-right:.5rem;z-index:1002}
-
-    body { }
-  </style>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -77,6 +50,7 @@
     "author": { "@type": "Organization", "name": "DailyJamm", "url": "https://dailyjamm.com" }
   }
   </script>
+  <script src="/assets/js/menu.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white">
 
@@ -413,31 +387,9 @@
     </div>
   </div>
 
+  <script src="/assets/js/utils.js" defer></script>
   <script src="/assets/js/roulettedle.js" defer></script>
 
-  <script>
-    (function(){
-      const drawer   = document.getElementById('drawer');
-      const backdrop = document.getElementById('backdrop');
-      function openMenu(){
-        drawer.classList.add('open');
-        backdrop.classList.add('open');
-        document.documentElement.classList.add('overflow-hidden');
-        document.addEventListener('keydown', onKey);
-      }
-      function closeMenu(){
-        drawer.classList.remove('open');
-        backdrop.classList.remove('open');
-        document.documentElement.classList.remove('overflow-hidden');
-        document.removeEventListener('keydown', onKey);
-      }
-      function toggleMenu(){
-        if(drawer.classList.contains('open')){ closeMenu(); } else { openMenu(); }
-      }
-      function onKey(e){ if(e.key === 'Escape') closeMenu(); }
-      window.toggleMenu = toggleMenu;
-      window.closeMenu  = closeMenu;
-    })();
-  </script>
+
 </body>
 </html>

--- a/spelldle/index.html
+++ b/spelldle/index.html
@@ -37,57 +37,10 @@
   <!-- Tailwind CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
 
-  <!-- Google AdSense -->
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4552090282675465" crossorigin="anonymous"></script>
 
   <style>
-    :root {
-      --panel: #0f172a;
-      --brand: #10b981;
-      --muted: #cbd5e1;
-      --line:  #1f2937;
-    }
-
-    /* Hamburger + drawer */
-    .hamburger{position:fixed;top:20px;left:20px;z-index:1000;cursor:pointer;background:transparent;border:none;padding:0;appearance:none;-webkit-appearance:none}
-    .hamburger:focus{outline:2px solid rgba(255,255,255,.25);outline-offset:4px;border-radius:10px}
-    .hamburger-box{width:30px;height:30px;display:flex;flex-direction:column;justify-content:space-around;background:transparent;border-radius:8px;padding:6px;transition:.3s}
-    .hamburger-box:hover{background:rgba(0,0,0,.3)}
-    .hamburger-line{width:100%;height:3px;background:#fff;border-radius:2px}
-    .backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);opacity:0;visibility:hidden;transition:.3s;z-index:998}
-    .backdrop.open{opacity:1;visibility:visible}
-    .drawer{position:fixed;top:0;left:-300px;width:300px;height:100vh;background:var(--panel);border-right:2px solid var(--brand);transition:left .3s ease;z-index:999;padding:80px 20px 20px;overflow-y:auto;-webkit-overflow-scrolling:touch}
-    .drawer.open{left:0}
-    .menu-sec{margin-bottom:1.5rem}
-    .menu-title{font-size:1rem;font-weight:700;color:var(--brand);margin-bottom:.75rem;padding-bottom:.5rem;border-bottom:1px solid var(--line)}
-    .menu-link{display:block;color:var(--muted);text-decoration:none;padding:.6rem 0;border-radius:5px;transition:.2s}
-    .menu-link:hover{color:#fff;background:rgba(16,185,129,.1);padding-left:.5rem}
-    header .hamburger{position:relative;top:auto;left:auto;margin-right:.5rem;z-index:1002}
-
     body { overflow: hidden; }
-
-    /* Prevent iOS zoom */
-    #spd-input { font-size: 16px; }
-
-    /* Modal */
-    #spd-modal { align-items: flex-end; padding: 0; }
-    #spd-modal > div {
-      border-radius: 1.25rem 1.25rem 0 0;
-      max-height: 92vh;
-      overflow-y: scroll;
-      -webkit-overflow-scrolling: touch;
-      overscroll-behavior: contain;
-      touch-action: pan-y;
-      padding-bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
-    }
-    @media (min-height: 600px) {
-      #spd-modal { align-items: center; padding: 1rem; }
-      #spd-modal > div {
-        border-radius: 1rem;
-        max-height: 85vh;
-        padding-bottom: 1.25rem;
-      }
-    }
+    #spd-input { font-size: 16px; } /* Prevent iOS auto-zoom on input focus */
   </style>
 
   <script type="application/ld+json">
@@ -103,6 +56,7 @@
     "author": { "@type": "Organization", "name": "DailyJamm", "url": "https://dailyjamm.com" }
   }
   </script>
+  <script src="/assets/js/menu.js" defer></script>
 </head>
 <body class="bg-gray-900 text-white">
 
@@ -322,34 +276,10 @@
     </div>
   </div>
 
+  <script src="/assets/js/utils.js" defer></script>
   <script src="/assets/js/spelldle.js" defer></script>
 
-  <script>
-    (function(){
-      var drawer   = document.getElementById('drawer');
-      var backdrop = document.getElementById('backdrop');
-      function openMenu(){
-        drawer.classList.add('open');
-        backdrop.classList.add('open');
-        document.documentElement.classList.add('overflow-hidden');
-        document.addEventListener('keydown', onKey);
-      }
-      function closeMenu(){
-        drawer.classList.remove('open');
-        backdrop.classList.remove('open');
-        document.documentElement.classList.remove('overflow-hidden');
-        document.removeEventListener('keydown', onKey);
-      }
-      function toggleMenu(){
-        if(drawer.classList.contains('open')){ closeMenu(); } else { openMenu(); }
-      }
-      function onKey(e){ if(e.key === 'Escape') closeMenu(); }
-      window.toggleMenu = toggleMenu;
-      window.closeMenu  = closeMenu;
-    })();
-  </script>
-
-  <!-- Cookie consent (required for AdSense) -->
+  <!-- Cookie consent -->
   <div id="dj-cookie-bar" style="display:none">
     <span>We use cookies for analytics and advertising. <a href="/privacy/">Privacy Policy</a></span>
     <button onclick="document.getElementById('dj-cookie-bar').style.display='none';localStorage.setItem('dj_cookie_ok','1')">Got it</button>

--- a/terms/index.html
+++ b/terms/index.html
@@ -34,8 +34,7 @@
 
   <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
-  <!-- Google AdSense -->
-  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4552090282675465" crossorigin="anonymous"></script>
+
 
   <style>
     :root {
@@ -75,6 +74,7 @@
     footer a { color: #6b7280; }
     footer a:hover { color: #fff; }
   </style>
+  <script src="/assets/js/menu.js" defer></script>
 </head>
 <body>
 
@@ -174,22 +174,10 @@
   </div>
 
   <script>
-    function toggleMenu() {
-      const d = document.getElementById('drawer');
-      const b = document.getElementById('backdrop');
-      const open = d.classList.toggle('open');
-      b.classList.toggle('open', open);
-      document.querySelector('.hamburger').setAttribute('aria-expanded', open ? 'true' : 'false');
-    }
-    function closeMenu() {
-      document.getElementById('drawer').classList.remove('open');
-      document.getElementById('backdrop').classList.remove('open');
-      document.querySelector('.hamburger').setAttribute('aria-expanded', 'false');
-    }
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 
-  <!-- Cookie consent (required for AdSense) -->
+  <!-- Cookie consent -->
   <div id="dj-cookie-bar" style="display:none">
     <span>We use cookies for analytics and advertising. <a href="/privacy/">Privacy Policy</a></span>
     <button onclick="document.getElementById('dj-cookie-bar').style.display='none';localStorage.setItem('dj_cookie_ok','1')">Got it</button>

--- a/themedle/index.html
+++ b/themedle/index.html
@@ -38,44 +38,6 @@
 
   <!-- Tailwind -->
   <script src="https://cdn.tailwindcss.com"></script>
-  <!-- AdSense not served on this page (copyrighted audio content) -->
-  <style>
-        :root{
-      /* Set sane defaults in case these aren't defined elsewhere */
-      --panel:#0f172a;       /* slate-900 */
-      --brand:#10b981;       /* emerald-500 */
-      --muted:#cbd5e1;       /* slate-300 */
-      --line:#1f2937;        /* slate-800 */
-    }
-
-    /* ======= HOMEPAGE HAMBURGER (exact classes/markup) ======= */
-    /* hamburger */
-    .hamburger{position:fixed;top:20px;left:20px;z-index:1000;cursor:pointer;background:transparent;border:none;padding:0;appearance:none;-webkit-appearance:none}
-    .hamburger:focus{outline:2px solid rgba(255,255,255,.25);outline-offset:4px;border-radius:10px}
-    .hamburger-box{width:30px;height:30px;display:flex;flex-direction:column;justify-content:space-around;background:transparent;border-radius:8px;padding:6px;transition:.3s}
-    .hamburger-box:hover{background:rgba(0,0,0,.3)}
-    .hamburger-line{width:100%;height:3px;background:#fff;border-radius:2px}
-    /* side menu */
-    .backdrop{position:fixed;inset:0;background:rgba(0,0,0,.5);opacity:0;visibility:hidden;transition:.3s;z-index:998}
-    .backdrop.open{opacity:1;visibility:visible}
-    .drawer{position:fixed;top:0;left:-300px;width:300px;height:100vh;background:var(--panel);border-right:2px solid var(--brand);transition:left .3s ease;z-index:999;padding:80px 20px 20px;overflow-y:auto;-webkit-overflow-scrolling:touch}
-    .drawer.open{left:0}
-    .menu-sec{margin-bottom:1.5rem}
-    .menu-title{font-size:1rem;font-weight:700;color:var(--brand);margin-bottom:.75rem;padding-bottom:.5rem;border-bottom:1px solid var(--line)}
-    .menu-link{display:block;color:var(--muted);text-decoration:none;padding:.6rem 0;border-radius:5px;transition:.2s}
-    .menu-link:hover{color:#fff;background:rgba(46,204,113,.1);padding-left:.5rem}
-
-    /* IMPORTANT: place hamburger just to the left of the DailyJamm logo
-       by overriding its position when it lives inside our header row */
-    header .hamburger{position:relative;top:auto;left:auto;margin-right:.5rem;z-index:1002}
-
-    /* Modal: scrollable on mobile with smooth iOS momentum */
-    #td-modal { align-items: flex-end; }
-    #td-modal > div { -webkit-overflow-scrolling: touch; overscroll-behavior: contain; }
-    @media (min-height: 600px) {
-      #td-modal { align-items: center; }
-    }
-  </style>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -89,6 +51,7 @@
     "author": { "@type": "Organization", "name": "DailyJamm", "url": "https://dailyjamm.com" }
   }
   </script>
+  <script src="/assets/js/menu.js" defer></script>
 </head>
 <body class="bg-gray-900 min-h-screen text-white">
   <!-- =============================== -->
@@ -429,6 +392,7 @@
   </footer>
 
   <!-- Main JS -->
+  <script src="/assets/js/utils.js" defer></script>
   <script src="/assets/js/main.js" defer></script>
 
   <!-- Minimal JS to match homepage behavior for the hamburger -->
@@ -537,31 +501,6 @@
       }
     })();
 
-    (function(){
-      const drawer = document.getElementById('drawer');
-      const backdrop = document.getElementById('backdrop');
-
-      function openMenu(){
-        drawer.classList.add('open');
-        backdrop.classList.add('open');
-        document.documentElement.classList.add('overflow-hidden');
-        document.addEventListener('keydown', onKey);
-      }
-      function closeMenu(){
-        drawer.classList.remove('open');
-        backdrop.classList.remove('open');
-        document.documentElement.classList.remove('overflow-hidden');
-        document.removeEventListener('keydown', onKey);
-      }
-      function toggleMenu(){
-        if(drawer.classList.contains('open')){ closeMenu(); } else { openMenu(); }
-      }
-      function onKey(e){ if(e.key === 'Escape') closeMenu(); }
-
-      // Expose globally for inline onclick="toggleMenu()"
-      window.toggleMenu = toggleMenu;
-      window.closeMenu = closeMenu;
-    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
- Add shared hamburger/drawer CSS and game-page :root variables to styles.css, removing ~50 lines of identical inline CSS from each game page
- Extract repeated hamburger toggle IIFE into assets/js/menu.js, referenced on all 9 pages via a single defer script tag
- Create assets/js/utils.js (window.DJUtils) with shared helpers: getChicagoDate, getChicagoMidnight, loadJSON, saveJSON, clipboardShare
- Update all 5 game JS files to use DJUtils instead of local copies of those helpers
- Wrap main.js (Themedle) in an IIFE with 'use strict'; expose only closeStatsModal on window for the one onclick handler in themedle/
- Replace all var declarations in spelldle.js with const/let
- Add named constants for magic numbers (SECONDS_PER_DAY, SECONDS_PER_HOUR, MS_PER_HOUR, MS_PER_MIN, MS_PER_SEC) in each game file
- Remove ads.txt (AdSense no longer in use)
- Remove AdSense references from CLAUDE.md checklist